### PR TITLE
리액트 라우터 core 기능 및 hooks 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,25 +1,17 @@
-import { useState } from 'react';
+import { Route, Router, Routes } from './lib/Router';
+import Chat from './pages/Chat';
+import Home from './pages/Home';
+import PostDetail from './pages/Post/PostDetail';
 
 function App() {
-  const [count, setCount] = useState(0);
-
   return (
-    <div className="App">
-      <div></div>
-
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vit e and React logos to learn more
-      </p>
-    </div>
+    <Router>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/product/:id" element={<PostDetail />} />
+        <Route path="/chat" element={<Chat />} />
+      </Routes>
+    </Router>
   );
 }
 export default App;

--- a/frontend/src/lib/Router/components/Link.tsx
+++ b/frontend/src/lib/Router/components/Link.tsx
@@ -1,0 +1,25 @@
+import { MouseEvent, useContext } from 'react';
+import { PathDispatch } from './PathProvider';
+
+interface LinkProps {
+  className?: string;
+  children: React.ReactNode;
+  to: string;
+}
+
+function Link({ className, children, to }: LinkProps) {
+  const pathDispatch = useContext(PathDispatch);
+
+  const handleClick = ({ preventDefault }: MouseEvent<HTMLAnchorElement>) => {
+    preventDefault();
+    pathDispatch(to);
+  };
+
+  return (
+    <a className={className} href={to} onClick={handleClick}>
+      {children}
+    </a>
+  );
+}
+
+export default Link;

--- a/frontend/src/lib/Router/components/PathProvider.tsx
+++ b/frontend/src/lib/Router/components/PathProvider.tsx
@@ -1,0 +1,37 @@
+import { createContext, useEffect, useState } from 'react';
+
+type PathDispatchType = (nextPath: string) => void;
+
+export const PathContext = createContext('/');
+export const PathDispatch = createContext<PathDispatchType>(() => undefined);
+
+function PathProvider({ children }: { children: React.ReactNode }) {
+  const [path, setPath] = useState(location.pathname);
+
+  const handlePathChange = (nextPath: string) => {
+    setPath(nextPath);
+    window.history.pushState(nextPath, '', nextPath);
+  };
+
+  useEffect(() => {
+    const handlePopState = (event: PopStateEvent) => {
+      setPath(event.state);
+    };
+
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, []);
+
+  return (
+    <PathContext.Provider value={path}>
+      <PathDispatch.Provider value={handlePathChange}>
+        {children}
+      </PathDispatch.Provider>
+    </PathContext.Provider>
+  );
+}
+
+export default PathProvider;

--- a/frontend/src/lib/Router/components/Route.tsx
+++ b/frontend/src/lib/Router/components/Route.tsx
@@ -1,0 +1,16 @@
+import { throwError } from '../utils';
+
+interface RouteProps {
+  path: string;
+  element: React.ReactNode;
+}
+
+function Route(_props: RouteProps) {
+  throwError(
+    'Route 컴포넌트는 Routes 컴포넌트의 자식이어야 합니다. 직접 호출하지마세요!',
+  );
+
+  return null;
+}
+
+export default Route;

--- a/frontend/src/lib/Router/components/Router.tsx
+++ b/frontend/src/lib/Router/components/Router.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import PathProvider from './PathProvider';
+
+function Router({ children }: { children: React.ReactNode }) {
+  return <PathProvider>{children}</PathProvider>;
+}
+
+export default Router;

--- a/frontend/src/lib/Router/components/Routes.tsx
+++ b/frontend/src/lib/Router/components/Routes.tsx
@@ -1,0 +1,38 @@
+import React, { Children, useContext } from 'react';
+import { PathContext } from './PathProvider';
+import {
+  isMatchedRoute,
+  isValidChild,
+  removeQueryString,
+  throwError,
+  transformPathVariables,
+} from '../utils';
+
+function Routes({ children }: { children: React.ReactNode }) {
+  const path = useContext(PathContext);
+
+  let currentRoute = null;
+  let _currentParams = null;
+
+  Children.forEach(children, (child: React.ReactNode) => {
+    if (!isValidChild(child)) {
+      throwError('올바른 Route 컴포넌트가 아닙니다.');
+      return;
+    }
+
+    const { path: routePath, element: routeElement } = child.props;
+
+    const { parsedPath, params } = transformPathVariables(
+      removeQueryString(routePath),
+    );
+
+    if (isMatchedRoute(parsedPath, path)) {
+      currentRoute = routeElement;
+      _currentParams = params;
+    }
+  });
+
+  return currentRoute;
+}
+
+export default Routes;

--- a/frontend/src/lib/Router/components/Routes.tsx
+++ b/frontend/src/lib/Router/components/Routes.tsx
@@ -7,12 +7,12 @@ import {
   throwError,
   transformPathVariables,
 } from '../utils';
+import location from '../location';
 
 function Routes({ children }: { children: React.ReactNode }) {
   const path = useContext(PathContext);
 
   let currentRoute = null;
-  let _currentParams = null;
 
   Children.forEach(children, (child: React.ReactNode) => {
     if (!isValidChild(child)) {
@@ -28,7 +28,10 @@ function Routes({ children }: { children: React.ReactNode }) {
 
     if (isMatchedRoute(parsedPath, path)) {
       currentRoute = routeElement;
-      _currentParams = params;
+      location.setLocation({
+        path: parsedPath,
+        params,
+      });
     }
   });
 

--- a/frontend/src/lib/Router/hooks.ts
+++ b/frontend/src/lib/Router/hooks.ts
@@ -1,0 +1,46 @@
+import { useContext } from 'react';
+import { PathContext, PathDispatch } from './components/PathProvider';
+import location from './location';
+
+export function usePathParams() {
+  const currentPath = useContext(PathContext);
+  const { path, params } = location.getLocation();
+  const paramsRegex = new RegExp(`^${path}$`);
+
+  const match = currentPath.match(paramsRegex);
+
+  if (!match) {
+    return {};
+  }
+
+  match.shift();
+
+  const result: {
+    [key: string]: string;
+  } = {};
+
+  return match.reduce(
+    (result, curr, idx) => {
+      console.log(curr);
+      result[params[idx]] = curr;
+
+      return result;
+    },
+    { ...result },
+  );
+}
+
+export function useNavigate(path: string) {
+  const pathDispatch = useContext(PathDispatch);
+
+  pathDispatch(path);
+}
+
+export function useSearchParams() {
+  const currentPath = useContext(PathContext);
+  const location = new URLSearchParams(currentPath);
+
+  return (query: string) => {
+    return location.get(query);
+  };
+}

--- a/frontend/src/lib/Router/index.tsx
+++ b/frontend/src/lib/Router/index.tsx
@@ -2,5 +2,14 @@ import Route from './components/Route';
 import Router from './components/Router';
 import Routes from './components/Routes';
 import Link from './components/Link';
+import { useNavigate, usePathParams, useSearchParams } from './hooks';
 
-export { Route, Router, Routes, Link };
+export {
+  Route,
+  Router,
+  Routes,
+  Link,
+  useNavigate,
+  usePathParams,
+  useSearchParams,
+};

--- a/frontend/src/lib/Router/index.tsx
+++ b/frontend/src/lib/Router/index.tsx
@@ -1,0 +1,6 @@
+import Route from './components/Route';
+import Router from './components/Router';
+import Routes from './components/Routes';
+import Link from './components/Link';
+
+export { Route, Router, Routes, Link };

--- a/frontend/src/lib/Router/location.ts
+++ b/frontend/src/lib/Router/location.ts
@@ -1,0 +1,24 @@
+interface LocationType {
+  path: string;
+  params: string[];
+}
+
+export default (function () {
+  let location: LocationType = {
+    path: '',
+    params: [],
+  };
+
+  const getLocation = () => {
+    return { ...location };
+  };
+
+  const setLocation = (newLocation: LocationType) => {
+    location = newLocation;
+  };
+
+  return {
+    getLocation,
+    setLocation,
+  };
+})();

--- a/frontend/src/lib/Router/utils.ts
+++ b/frontend/src/lib/Router/utils.ts
@@ -1,0 +1,53 @@
+import React, { isValidElement } from 'react';
+
+const ROUTE_PARAMETER_REGEX = /:(\w+)/g;
+const QUERY_STRING_REGEXP = /\?[\w=&]+/g;
+const URL_FRAGMENT = '([^\\/]+)';
+
+export function throwError(message: string) {
+  throw new Error(message);
+}
+
+export function isRouteComponent(element: React.ReactElement) {
+  return element.props.path && element.props.element;
+}
+
+export function isValidChild(
+  child: React.ReactNode,
+): child is React.ReactElement {
+  if (!isValidElement(child)) {
+    return false;
+  }
+
+  if (!isRouteComponent(child)) {
+    return false;
+  }
+
+  return true;
+}
+
+export function removeQueryString(routePath: string) {
+  return routePath.replace(QUERY_STRING_REGEXP, '');
+}
+
+export function transformPathVariables(routePath: string) {
+  const params: string[] = [];
+  const parsedPath = routePath.replace(
+    ROUTE_PARAMETER_REGEX,
+    (_match: string, paramName: string) => {
+      params.push(paramName);
+      return URL_FRAGMENT;
+    },
+  );
+
+  return {
+    parsedPath,
+    params,
+  };
+}
+
+export function isMatchedRoute(parsedPath: string, pathname: string) {
+  const pathRegExp = new RegExp(`^${parsedPath}$`);
+
+  return pathRegExp.test(pathname);
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,12 @@
+import { Link } from '../lib/Router';
+
 function Home() {
-  return <div>Home</div>;
+  return (
+    <main>
+      <h1>HOme</h1>
+      <Link to="/chat">챗으로가자~</Link>
+    </main>
+  );
 }
 
 export default Home;


### PR DESCRIPTION
## 📎 관련 이슈
#1 

## 💥 PR Point
location 어떻게 구현하는 게 더 좋았을까요?
처음에는 context로 데이터를 공유하려고 했지만 최상위 provider가 리렌더되면서 다시 Routes에서 Children을 탐색하는 과정이 반복되며 무한 렌더링이 발생하고 말았다.
=> 이에 대한 해결책으로 context를 버리고 일반적인 js 로직을 import 하는 형식으로 해결했다.

## 👻 실제 소요시간
2h 30m

## 😭 어려웠던 점
pathParams를 추출하는 과정이 생각보다 까다로웠다.