### PR TITLE
라우팅 간 state 전달하는 기능 추가

### DIFF
--- a/frontend/src/lib/Router/components/Link.tsx
+++ b/frontend/src/lib/Router/components/Link.tsx
@@ -5,14 +5,15 @@ interface LinkProps {
   className?: string;
   children: React.ReactNode;
   to: string;
+  state?: any;
 }
 
-function Link({ className, children, to }: LinkProps) {
+function Link({ className, children, to, state }: LinkProps) {
   const navigate = useNavigate();
 
   const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    navigate(to);
+    navigate(to, state);
   };
 
   return (

--- a/frontend/src/lib/Router/components/Link.tsx
+++ b/frontend/src/lib/Router/components/Link.tsx
@@ -10,8 +10,8 @@ interface LinkProps {
 function Link({ className, children, to }: LinkProps) {
   const navigate = useNavigate();
 
-  const handleClick = ({ preventDefault }: MouseEvent<HTMLAnchorElement>) => {
-    preventDefault();
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
     navigate(to);
   };
 

--- a/frontend/src/lib/Router/components/LinkButton.tsx
+++ b/frontend/src/lib/Router/components/LinkButton.tsx
@@ -4,13 +4,14 @@ interface LinkButtonProps {
   className?: string;
   children: React.ReactNode;
   moveTo: string;
+  state?: any;
 }
 
-function LinkButton({ className, children, moveTo }: LinkButtonProps) {
+function LinkButton({ className, children, moveTo, state }: LinkButtonProps) {
   const navigate = useNavigate();
 
   const handleLinkButtonClick = () => {
-    navigate(moveTo);
+    navigate(moveTo, state);
   };
 
   return (

--- a/frontend/src/lib/Router/components/PathProvider.tsx
+++ b/frontend/src/lib/Router/components/PathProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useEffect, useState } from 'react';
 
-type PathDispatchType = (nextPath: string) => void;
+type PathDispatchType = (nextPath: string, state?: any) => void;
 
 export const PathContext = createContext('/');
 export const PathDispatch = createContext<PathDispatchType>(() => undefined);
@@ -8,14 +8,14 @@ export const PathDispatch = createContext<PathDispatchType>(() => undefined);
 function PathProvider({ children }: { children: React.ReactNode }) {
   const [path, setPath] = useState(location.pathname);
 
-  const handlePathChange = (nextPath: string) => {
+  const handlePathChange = (nextPath: string, state?: any) => {
     setPath(nextPath);
-    window.history.pushState(nextPath, '', nextPath);
+    window.history.pushState(state, '', nextPath);
   };
 
   useEffect(() => {
-    const handlePopState = (event: PopStateEvent) => {
-      setPath(event.state || window.location.pathname);
+    const handlePopState = () => {
+      setPath(window.location.pathname);
     };
 
     window.addEventListener('popstate', handlePopState);

--- a/frontend/src/lib/Router/hooks.ts
+++ b/frontend/src/lib/Router/hooks.ts
@@ -32,9 +32,7 @@ export function usePathParams() {
 export function useNavigate() {
   const pathDispatch = useContext(PathDispatch);
 
-  return (path: string) => {
-    pathDispatch(path);
-  };
+  return pathDispatch;
 }
 
 export function useSearchParams() {
@@ -44,4 +42,13 @@ export function useSearchParams() {
   return (query: string) => {
     return location.get(query);
   };
+}
+
+export function useHistoryState() {
+  const currentState = window.history.state;
+  if (!currentState) {
+    return null;
+  }
+
+  return currentState;
 }


### PR DESCRIPTION
## 📎 관련 이슈

#13 
* closes #13 

## 💥 PR Point

```javascript
export function useHistoryState() {
  const currentState = window.history.state;
  if (!currentState) {
    return null;
  }

  return currentState;
}
```

다음과 같이 react-router처럼 커스텀 훅으로 state를 가져오고자했는데 
막상 구현해보고나니 이 함수가 커스텀훅일 필요가 전혀 없어보이네요.

location처럼 모듈패턴을 적용해서 구현하는게 더 나을까요?

그래도 사용하는 쪽에서는 .. 좀 이쁘긴합니다 ㅎㅎ;

```javascript
// to route
navigate('/some-url', { foo: 'bar' });

// routed Page
const state = useHistoryState(); // { foo: 'bar' }
```

## 👻 실제 소요시간

15분

## 😭 어려웠던 점

어려웠던 점? 이라기보다는 고민했던 점에 대해서 linked issue의 코멘트에 달아놨습니다 ! 
