### PR TITLE
decoded undefined 로 나오는 이슈 수정

### DIFF
--- a/backend/src/domain/auth/auth.service.ts
+++ b/backend/src/domain/auth/auth.service.ts
@@ -138,13 +138,21 @@ export class AuthService {
 
   async getUserInfo(token: string) {
     try {
-      const decoded = jwt.verify(
-        token,
-        this.configService.get('JWT_SECRET_KEY'),
-        (error) => {
-          JWT_ERROR_MAP[error.message]();
-        },
-      );
+      const decoded = await new Promise((resolve, reject) => {
+        jwt.verify(
+          token,
+          this.configService.get('JWT_SECRET_KEY'),
+          (error, decoded) => {
+            if (error) {
+              if (error.message in JWT_ERROR_MAP)
+                JWT_ERROR_MAP[error.message]();
+              else reject(error.message);
+            }
+
+            resolve(decoded);
+          },
+        );
+      });
 
       return decoded;
     } catch (e) {


### PR DESCRIPTION
## 💥 PR Point

jwt 자체가 비동기함수여서 jwt.verify()의 반환값이 undefined가 찍히더라구요.
루터에서 할 때는 잘됐던 것 같은데 어느 부분에서 놓쳤던 걸까요?

Promise로 래핑해서 jwt.verfiy의 콜백함수 인자 값을 사용해서 해결했습니다.

## 👻 실제 소요시간

30m

## 😭 어려웠던 점

페어하면서 같이 테스트하고 머지했는데  집에와서 작업할 때 새로고침 유지가 안되어서 원인 파악에 시간이 걸렸어요
