### PR TITLE
파일 멀티 업로드, 썸네일 삭제 기능 추가

### DIFF
--- a/frontend/src/components/Post/ImagePreview.tsx
+++ b/frontend/src/components/Post/ImagePreview.tsx
@@ -1,5 +1,0 @@
-function ImagePreview() {
-  return <li>ImagePreview</li>;
-}
-
-export default ImagePreview;

--- a/frontend/src/components/Post/ImagePreviewList.tsx
+++ b/frontend/src/components/Post/ImagePreviewList.tsx
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+import { CloseIcon } from '../../assets/icons/icons';
+import colors from '../../styles/colors';
+
+interface ImagePreviewListProps {
+  thumbnails: string[];
+  setThumbnails: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+function ImagePreviewList({
+  thumbnails,
+  setThumbnails,
+}: ImagePreviewListProps) {
+  const handleDeleteThumbnail = (url: string) => {
+    setThumbnails((prev) => prev.filter((item) => item !== url));
+  };
+
+  return (
+    <StyledImagePreviewList>
+      {thumbnails.map((url) => (
+        <li className="image-preview-item" key={url}>
+          <img className="post-image" src={url} alt="post_images" />
+          <button
+            className="image-preview-delete-btn"
+            type="button"
+            onClick={() => handleDeleteThumbnail(url)}
+          >
+            <CloseIcon />
+          </button>
+        </li>
+      ))}
+    </StyledImagePreviewList>
+  );
+}
+
+export default ImagePreviewList;
+
+const StyledImagePreviewList = styled.ul`
+  display: flex;
+
+  .image-preview-item {
+    position: relative;
+
+    .image-preview-delete-btn {
+      position: absolute;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      top: -0.5rem;
+      right: 0.5rem;
+      border-radius: 50%;
+      background-color: ${colors.black};
+
+      svg path {
+        stroke: ${colors.white};
+      }
+    }
+  }
+`;

--- a/frontend/src/pages/Post/PostManager.tsx
+++ b/frontend/src/pages/Post/PostManager.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { CheckIcon, ImageIcon, MapPinIcon } from '../../assets/icons/icons';
 import withCheckLogin from '../../components/HOC/withCheckLogin';
 import PageHeader from '../../components/PageHeader/PageHeader';
+import ImagePreviewList from '../../components/Post/ImagePreviewList';
 import { UserInfoContext } from '../../context/UserInfoContext';
 import useQuery from '../../hooks/useQuery';
 import { remote } from '../../lib/api';
@@ -19,11 +20,7 @@ function PostManager() {
       return result.data;
     },
   );
-  const [thumbnails, setThumbnails] = useState([
-    'https://web-flea-6.s3.ap-northeast-2.amazonaws.com/1661131387060_Sl_i5bb7y',
-    'https://web-flea-6.s3.ap-northeast-2.amazonaws.com/1661139595547_lEfMjTNql',
-    'https://web-flea-6.s3.ap-northeast-2.amazonaws.com/1661139603973_kt0qFS0Lc',
-  ]);
+  const [thumbnails, setThumbnails] = useState<string[]>([]);
   const userInfo = useContext(UserInfoContext);
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
@@ -33,13 +30,14 @@ function PostManager() {
 
   const onFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
+    console.log(files);
 
     if (!files) {
       return;
     }
 
     const formData = new FormData();
-    formData.append('thumbnails', files[0]);
+    [...files].forEach((file) => formData.append('thumbnails', file));
 
     const res = await remote.post('product/upload', formData, {
       headers: {
@@ -47,7 +45,7 @@ function PostManager() {
       },
     });
 
-    setThumbnails((prev) => [...prev, res.data]);
+    setThumbnails((prev) => [...prev, ...res.data]);
   };
 
   const handleWritePost = async (
@@ -103,14 +101,12 @@ function PostManager() {
             type="file"
             onChange={onFileUpload}
             accept="image/*"
+            multiple
           />
-          <ul className="image-list">
-            {thumbnails.map((url) => (
-              <li key={url}>
-                <img className="post-image" src={url} alt="post_images" />
-              </li>
-            ))}
-          </ul>
+          <ImagePreviewList
+            thumbnails={thumbnails}
+            setThumbnails={setThumbnails}
+          />
         </div>
         <div className="content-section">
           <div className="post-meta">
@@ -189,7 +185,7 @@ const StyledPostForm = styled.form`
   flex: 1 1 100%;
   display: flex;
   flex-direction: column;
-  padding: 1.5rem 1rem;
+  padding: 0 1rem 1.5rem 1rem;
 
   input[type='file'] {
     display: none;
@@ -197,13 +193,9 @@ const StyledPostForm = styled.form`
 
   .image-section {
     width: 100%;
-    padding-bottom: 1.5rem;
+    padding: 1.5rem 0;
     overflow-y: scroll;
     display: flex;
-
-    .image-list {
-      display: flex;
-    }
 
     .image-upload {
       flex-shrink: 0;

--- a/frontend/src/pages/Post/PostManager.tsx
+++ b/frontend/src/pages/Post/PostManager.tsx
@@ -30,7 +30,6 @@ function PostManager() {
 
   const onFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
-    console.log(files);
 
     if (!files) {
       return;


### PR DESCRIPTION
## 📎 관련 이슈
#61 

## 💥 PR Point
글쓰기 페이지에서 썸네일 여러 장 업로드와 썸네일 삭제 버튼 클릭 시 삭제되도록 기능을 개선했습니다.

<img width="546" alt="image" src="https://user-images.githubusercontent.com/60131316/186347578-f136d36a-1891-44f5-b92b-c0b2c40822ca.png">

## 👻 실제 소요시간
20m

## 😭 어려웠던 점
파일 멀티 업로드 시 배열 형태로 값이 오고가는 걸 고려해야 했습니다.