### PR TITLE
상품 수정하기 관련 기능

### DIFF
--- a/backend/src/domain/product/product.controller.ts
+++ b/backend/src/domain/product/product.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Param,
+  Patch,
   Post,
   Query,
   UploadedFiles,
@@ -11,10 +12,11 @@ import {
 import { FilesInterceptor } from '@nestjs/platform-express';
 import { ProductService } from './product.service';
 import {
+  CreateProductDTO,
+  ModifyProductDTO,
   ProductLikeRequestBody,
   ProductParam,
   ProductsGetOptions,
-  PostType,
 } from './types/product';
 
 @Controller('product')
@@ -22,7 +24,7 @@ export class ProductController {
   constructor(private readonly productService: ProductService) {}
 
   @Post('write')
-  async writePost(@Body() post: PostType) {
+  async writePost(@Body() post: CreateProductDTO) {
     return this.productService.writePost(post);
   }
 
@@ -36,6 +38,16 @@ export class ProductController {
       productId,
       isLiked,
     });
+  }
+
+  @Patch(':productId')
+  modifyProductById(
+    @Param()
+    { productId }: ProductParam,
+    @Body()
+    modifyProductDto: Partial<ModifyProductDTO>,
+  ) {
+    return this.productService.modifyPostById(productId, modifyProductDto);
   }
 
   @Get(':productId')

--- a/backend/src/domain/product/product.controller.ts
+++ b/backend/src/domain/product/product.controller.ts
@@ -49,6 +49,7 @@ export class ProductController {
     modifyProductDto: Partial<ModifyProductDTO>,
   ) {
     return this.productService.modifyPostById(productId, modifyProductDto);
+  }
 
   @Delete(':productId')
   deleteProductById(

--- a/backend/src/domain/product/product.service.ts
+++ b/backend/src/domain/product/product.service.ts
@@ -1,5 +1,5 @@
 import { HttpException, Injectable } from '@nestjs/common';
-import { Pool } from 'mysql2/promise';
+import { Pool, ResultSetHeader } from 'mysql2/promise';
 import { MySQLService } from 'src/config/mysql/mysql.service';
 import { S3Service } from 'src/config/s3/s3.service';
 import {
@@ -155,7 +155,10 @@ export class ProductService {
         VALUES (${Object.values(postData).map(formatData).join()})
         `);
 
-      return res;
+      const { insertId } = res as ResultSetHeader;
+      return {
+        productId: insertId,
+      };
     } catch (e) {
       console.error(e);
       throw new HttpException('Failed to upload Post.', 500);

--- a/backend/src/domain/product/product.service.ts
+++ b/backend/src/domain/product/product.service.ts
@@ -182,7 +182,7 @@ export class ProductService {
 
     const modifedResult = res as ResultSetHeader;
     if (!modifedResult?.changedRows) {
-      throw new HttpException('Something wrong when delete Product', 422);
+      throw new HttpException('Nothing changed.', 422);
     }
 
     return post;

--- a/backend/src/domain/product/product.service.ts
+++ b/backend/src/domain/product/product.service.ts
@@ -6,7 +6,8 @@ import {
   ProductLikeRequestBody,
   ProductParam,
   ProductsGetOptions,
-  PostType,
+  CreateProductDTO,
+  ModifyProductDTO,
 } from './types/product';
 import formatData from 'src/utils/format';
 
@@ -141,7 +142,7 @@ export class ProductService {
     }
   }
 
-  async writePost(post: PostType) {
+  async writePost(post: CreateProductDTO) {
     try {
       const postData = {
         ...post,
@@ -163,5 +164,27 @@ export class ProductService {
       console.error(e);
       throw new HttpException('Failed to upload Post.', 500);
     }
+  }
+
+  async modifyPostById(productId: number, post: Partial<ModifyProductDTO>) {
+    const isExist = await this.isProductExist(productId);
+    if (!isExist) {
+      throw new HttpException(`Cannot found Product.`, 404);
+    }
+
+    const modifyTemplate = Object.entries(post)
+      .map(([key, val]) => `${key}= ${formatData(val)}`)
+      .join(', ');
+
+    const [res] = await this.pool.query(/*sql*/ `
+      UPDATE PRODUCT SET ${modifyTemplate} WHERE id = ${productId};
+    `);
+
+    const modifedResult = res as ResultSetHeader;
+    if (!modifedResult?.changedRows) {
+      throw new HttpException('Something wrong when delete Product', 422);
+    }
+
+    return post;
   }
 }

--- a/backend/src/domain/product/types/product.ts
+++ b/backend/src/domain/product/types/product.ts
@@ -1,4 +1,11 @@
-import { IsOptional, IsNumber, IsString, IsBoolean } from 'class-validator';
+import { OmitType } from '@nestjs/mapped-types';
+import {
+  IsOptional,
+  IsNumber,
+  IsString,
+  IsBoolean,
+  IsJSON,
+} from 'class-validator';
 
 export type ProductFilterType = 'sale' | 'like';
 
@@ -33,11 +40,26 @@ export class ProductLikeRequestBody {
   userId: number;
 }
 
-export interface PostType {
+export class CreateProductDTO {
+  @IsString()
   name: string;
+
+  @IsNumber()
   price: number;
+
+  @IsString()
   description: string;
+
+  @IsJSON()
   thumbnails: string[];
+
+  @IsNumber()
   categoryId: number;
+
+  @IsNumber()
   authorId: number;
+}
+
+export class ModifyProductDTO extends OmitType(CreateProductDTO, ['authorId']) {
+  isSold: boolean;
 }

--- a/frontend/src/components/Post/ImagePreviewList.tsx
+++ b/frontend/src/components/Post/ImagePreviewList.tsx
@@ -4,17 +4,13 @@ import colors from '../../styles/colors';
 
 interface ImagePreviewListProps {
   thumbnails: string[];
-  setThumbnails: React.Dispatch<React.SetStateAction<string[]>>;
+  handleDeleteThumbnail: (url: string) => void;
 }
 
 function ImagePreviewList({
   thumbnails,
-  setThumbnails,
+  handleDeleteThumbnail,
 }: ImagePreviewListProps) {
-  const handleDeleteThumbnail = (url: string) => {
-    setThumbnails((prev) => prev.filter((item) => item !== url));
-  };
-
   return (
     <StyledImagePreviewList>
       {thumbnails.map((url) => (

--- a/frontend/src/hooks/useProductInfiniteScroll.ts
+++ b/frontend/src/hooks/useProductInfiniteScroll.ts
@@ -27,11 +27,7 @@ function useProductInfiniteScroll(loader: React.RefObject<HTMLDivElement>) {
           '/product?' + categoryQueryString + userQueryString + pageQueryString,
         );
         const lastPage = Math.ceil(data.totalCount / 10);
-        console.log(
-          lastPage,
-          data.totalCount,
-          `/product?${categoryQueryString}${userQueryString}${pageQueryString}`,
-        );
+
         setProducts((prev) => [...prev, ...data.data]);
         setIsLoading(false);
         setIsLastPage(lastPage === page);

--- a/frontend/src/hooks/useQuery.ts
+++ b/frontend/src/hooks/useQuery.ts
@@ -15,7 +15,10 @@ export type RefetchArgs = any[];
 function useQuery<T>(
   queryKeyWithArgs: [QueryKey, ...RefetchArgs],
   queryFn: QueryFn<T>,
-  expireTime?: number,
+  queryOptions?: {
+    expireTime?: number;
+    skip?: boolean;
+  },
 ) {
   const [queryKey, ...refetchArgs] = queryKeyWithArgs;
   const [data, setData] = useState<T>();
@@ -31,7 +34,7 @@ function useQuery<T>(
         memoryCache.setCacheData(queryKey, queryFn, {
           fetchedData: result,
           refetchArgs,
-          expireTime,
+          expireTime: queryOptions?.expireTime,
         });
 
         setData(result);
@@ -42,6 +45,8 @@ function useQuery<T>(
       }
     }
 
+    if (queryOptions?.skip) return;
+
     const cacheData = memoryCache.getCacheData(queryKey, refetchArgs);
     if (!cacheData) {
       fetchFromRemote();
@@ -50,7 +55,7 @@ function useQuery<T>(
 
     setData(cacheData);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [queryKey, ...refetchArgs]);
+  }, [queryKey, ...refetchArgs, queryOptions?.skip]);
 
   return { data, isLoading };
 }

--- a/frontend/src/pages/Post/PostDetail.tsx
+++ b/frontend/src/pages/Post/PostDetail.tsx
@@ -176,12 +176,21 @@ const SellerInfo = styled.div`
 `;
 
 const PostFooter = styled.footer<{ isLiked: boolean }>`
+  position: sticky;
+  bottom: 0;
+
   display: flex;
   justify-content: space-between;
   align-items: center;
 
   padding: 1rem;
   border: 1px solid ${colors.gray200};
+  border-left-width: 0;
+  border-right-width: 0;
+
+  ${mixin.shadow.normal};
+
+  background-color: white;
 
   svg {
     ${({ isLiked }) =>

--- a/frontend/src/pages/Post/PostManager.tsx
+++ b/frontend/src/pages/Post/PostManager.tsx
@@ -140,6 +140,11 @@ function PostManager() {
 
   useEffect(() => {
     if (prevProductDetail) {
+      if (prevProductDetail.authorId !== userInfo.userId) {
+        navigate(`/post/${prevProductDetail.id}`, { replace: true });
+        return;
+      }
+
       const { name, description, categoryId, thumbnail, price } =
         prevProductDetail;
 
@@ -156,7 +161,7 @@ function PostManager() {
         price,
       });
     }
-  }, [prevProductDetail]);
+  }, [prevProductDetail, userInfo, navigate]);
 
   return (
     <StyledWrapper>

--- a/frontend/src/pages/Post/PostManager.tsx
+++ b/frontend/src/pages/Post/PostManager.tsx
@@ -123,9 +123,9 @@ function PostManager() {
 
     const { data } = await submitMethod(submitUrl, post);
     const productId = prevProductDetail?.id || data?.productId;
-    const returnUrl = productId ? `/post/${productId}` : '/';
+    const returnUrl = isEditMode ? -1 : `/post/${productId}`;
 
-    memoryCache.removeCacheData('postDetail' + data.productId);
+    memoryCache.removeCacheData('postDetail' + productId);
     navigate(returnUrl, {
       replace: true,
     });

--- a/frontend/src/pages/Post/PostManager.tsx
+++ b/frontend/src/pages/Post/PostManager.tsx
@@ -122,8 +122,13 @@ function PostManager() {
       : '/product/write';
 
     const { data } = await submitMethod(submitUrl, post);
+    const productId = prevProductDetail?.id || data?.productId;
+    const returnUrl = productId ? `/post/${productId}` : '/';
+
     memoryCache.removeCacheData('postDetail' + data.productId);
-    navigate(`/post/${data.productId}`, { replace: true });
+    navigate(returnUrl, {
+      replace: true,
+    });
   };
 
   const handleDeleteThumbnail = (url: string) => {

--- a/frontend/src/styles/colors.ts
+++ b/frontend/src/styles/colors.ts
@@ -9,6 +9,7 @@ const colors = {
   offWhite: '#f6f6f6',
   white: '#fff',
   red: '#f45452',
+  mint: '#2ac1bc',
 };
 
 export default colors;

--- a/frontend/src/utils/parse.ts
+++ b/frontend/src/utils/parse.ts
@@ -27,3 +27,11 @@ export const parseDateFromNow = (date: string) => {
 
   return `${Math.floor(betweenTimeDay / 365)}년전`;
 };
+
+export const parseLocaleStringToNumber = (
+  localeString: string,
+  maxPrice: number,
+) => {
+  const parsedNumber = Number(localeString.replace(/[^0-9]/g, ''));
+  return parsedNumber >= maxPrice ? maxPrice - 1 : parsedNumber;
+};


### PR DESCRIPTION
## 📎 관련 이슈

* closes #56 

## 💥 PR Point

### PostManager의 핸들러 통일
 
```typescript
  const handleChange = <T extends keyof ProductInputsType>(
    inputName: T,
    value: ProductInputsType[T],
  ) => {
    setProductInputs((prev) => ({
      ...prev,
      [inputName]: value,
    }));
  };
```

위와 같은 형태로 input 핸들러를 통일했어요.

---

### useQuery에 옵션 추가

useQuery에 특정 경우에는 api 콜을 넘어가도록하는 skip 옵션을 추가했어요.

```typescript
  const { data: prevProductDetail } = useQuery<ProductDetail>(
    ['postDetail' + productId, productId],
    async () => {
      const { data } = await remote(`/product/${productId}`);
      return data;
    },
    { skip: productId === null },
  );
```

productId 가 있을 때만 요청을 보냄으로써 유저가 수정 목적으로 접근했을 때에만 해당 id에 대한 상품정보를 불러오도록 구현했어요.

---

### 수정하기 fallback 

🚧  상품의 주인이 아닌 유저가 수정 목적으로 접근하면 수정페이지가 아닌 해당 상품의 상세페이지로 fallback 시켰어요.

## 👻 실제 소요시간

1h 10m

## 😭 어려웠던 점

크게 없었습니다 : )
